### PR TITLE
Avoid ClassCastException

### DIFF
--- a/src/main/java/com/squarespace/jersey2/guice/BindingUtils.java
+++ b/src/main/java/com/squarespace/jersey2/guice/BindingUtils.java
@@ -190,7 +190,7 @@ class BindingUtils {
    */
   public static boolean isContract(Injectee injectee) {
     Type type = injectee.getRequiredType();
-    return ((Class<?>)type).isAnnotationPresent(Contract.class);
+    return type instanceof Class && ((Class<?>)type).isAnnotationPresent(Contract.class);
   }
   
   /**


### PR DESCRIPTION
Avoid ClassCastException when injectee doesn't refer to a Class, but for example to a ParameterizedType